### PR TITLE
Rewrite parser functions in Rusty style, using peekable iterator;

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,13 +5,13 @@ use std::path::Path;
 
 // Start a custom repl
 fn main() {
-    let input = include_str!("test.qasm");
+    let input = include_str!("qft.qasm");
     let cwd = Path::new(file!()).parent().unwrap();
 
     let processed = process(input, cwd);
-    let mut tokens = lex(&processed);
+    let tokens = lex(&processed);
 
-    match parse(&mut tokens) {
+    match parse(&tokens) {
         Ok(ast) => {
             println!("AST: {:?}", ast);
             println!("\x1b[32mAll Okay!\x1b[0m");

--- a/examples/qft.qasm
+++ b/examples/qft.qasm
@@ -1,0 +1,23 @@
+// QFT and measure, version 2
+OPENQASM 2.0;
+
+qubit q[4];
+creg c[4];
+
+reset q;
+h q;
+barrier q;
+h q[0];
+measure q[0] -> c[0];
+if (c == 1) rz(pi / 2) q[1];
+h q[1];
+measure q[1] -> c[1];
+if(c==1) rz(pi / 4) q[2];
+if(c==1) rz(pi / 2) q[2];
+h q[2];
+measure q[2] -> c[2];
+if(c == 1) rz(pi / 8) q[3];
+if(c == 1) rz(pi / 4) q[3];
+if(c == 1) rz(pi / 2) q[3];
+h q[3];
+measure q[3] -> c[3];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,21 +317,7 @@ pub fn lex(input: &str) -> Vec<token::Token> {
 ///
 /// // Ok([QReg("a", 3), ApplyGate("CX", [Qubit("a", 0), Qubit("a", 1)], [])])
 /// ```
-pub fn parse(tokens: &mut Vec<token::Token>) -> Result<Vec<AstNode>> {
-    let mut nodes = vec![];
-
-    // Check that the version is first, and that it is version 2.0
-    if tokens.remove(0) != token::Token::OpenQASM {
-        return Err(Error::MissingVersion);
-    }
-    if parser::version(tokens)? != 2.0 {
-        return Err(Error::UnsupportedVersion);
-    }
-
-    while !tokens.is_empty() {
-        let node = parser::parse_node(tokens)?;
-        nodes.push(node);
-    }
-
-    Ok(nodes)
+pub fn parse(tokens: &Vec<token::Token>) -> Result<Vec<AstNode>> {
+    let mut tokens = tokens.iter().peekable();
+    parser::parse(&mut tokens)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -49,7 +49,7 @@ fn parse_node(tokens: &mut TokenStream) -> Result<AstNode> {
 
 pub fn version(tokens: &mut TokenStream) -> Result<f32> {
     match_token(tokens, Token::OpenQASM)
-        .map_err(|_| Error::MissingVersion);
+        .map_err(|_| Error::MissingVersion)?;
     let version = match_real(tokens)?;
     match_semicolon(tokens)?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,15 +2,37 @@
 //! Most methods are not documented, and should only be accessed
 //! indirectly from the `parse` method.
 
+use std::iter::Peekable;
 use token::Token;
 use error::Error;
 use ast::{Argument, AstNode};
 use std::result;
 
+const SUPPORTED_VERSIONS: [f32; 1] = [
+    2.0,
+];
+
+type TokenStream<'a> = Peekable<std::slice::Iter<'a, Token>>;
 type Result<T> = result::Result<T, Error>;
 
-pub fn parse_node(tokens: &mut Vec<Token>) -> Result<AstNode> {
-    match tokens.remove(0) {
+pub fn parse(tokens: &mut TokenStream) -> Result<Vec<AstNode>> {
+    let mut nodes = vec![];
+
+    // Check that the version is first, and that it is version 2.0
+    if !SUPPORTED_VERSIONS.contains(&version(tokens)?) {
+        return Err(Error::UnsupportedVersion);
+    }
+
+    while let Some(token) = tokens.peek() {
+        let node = parse_node(tokens)?;
+        nodes.push(node);
+    }
+
+    Ok(nodes)
+}
+
+fn parse_node(tokens: &mut TokenStream) -> Result<AstNode> {
+    match tokens.next().ok_or(Error::SourceError)?.clone() {
         Token::QReg => qreg(tokens),
         Token::CReg => creg(tokens),
         Token::Barrier => barrier(tokens),
@@ -25,19 +47,19 @@ pub fn parse_node(tokens: &mut Vec<Token>) -> Result<AstNode> {
     }
 }
 
-pub fn version(tokens: &mut Vec<Token>) -> Result<f32> {
+pub fn version(tokens: &mut TokenStream) -> Result<f32> {
+    match_token(tokens, Token::OpenQASM)
+        .map_err(|_| Error::MissingVersion);
     let version = match_real(tokens)?;
     match_semicolon(tokens)?;
 
     Ok(version)
 }
 
-pub fn qreg(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn qreg(tokens: &mut TokenStream) -> Result<AstNode> {
     // QReg -> Identifier -> Left Square Bracket -> Int -> Right Square Bracket -> Semicolon
     let identifier = match_identifier(tokens)?;
-
     match_token(tokens, Token::LSParen)?;
-
     let num = match_nninteger(tokens)?;
     match_token(tokens, Token::RSParen)?;
     match_semicolon(tokens)?;
@@ -45,12 +67,10 @@ pub fn qreg(tokens: &mut Vec<Token>) -> Result<AstNode> {
     Ok(AstNode::QReg(identifier, num))
 }
 
-pub fn creg(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn creg(tokens: &mut TokenStream) -> Result<AstNode> {
     // CReg -> Identifier -> Left Square Bracket -> Int -> Right Square Bracket -> Semicolon
     let identifier = match_identifier(tokens)?;
-
     match_token(tokens, Token::LSParen)?;
-
     let num = match_nninteger(tokens)?;
     match_token(tokens, Token::RSParen)?;
     match_semicolon(tokens)?;
@@ -58,7 +78,7 @@ pub fn creg(tokens: &mut Vec<Token>) -> Result<AstNode> {
     Ok(AstNode::CReg(identifier, num))
 }
 
-pub fn if_(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn if_(tokens: &mut TokenStream) -> Result<AstNode> {
     match_token(tokens, Token::LParen)?;
     let id = match_identifier(tokens)?;
     match_token(tokens, Token::Equals)?;
@@ -69,21 +89,23 @@ pub fn if_(tokens: &mut Vec<Token>) -> Result<AstNode> {
     Ok(AstNode::If(id, val, Box::new(node)))
 }
 
-pub fn barrier(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn barrier(tokens: &mut TokenStream) -> Result<AstNode> {
     // Barrier -> Argument -> Semicolon
     let argument = match_argument(tokens)?;
     match_semicolon(tokens)?;
+
     Ok(AstNode::Barrier(argument))
 }
 
-pub fn reset(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn reset(tokens: &mut TokenStream) -> Result<AstNode> {
     // reset -> Argument -> Semicolon
     let argument = match_argument(tokens)?;
     match_semicolon(tokens)?;
+
     Ok(AstNode::Reset(argument))
 }
 
-pub fn measure(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn measure(tokens: &mut TokenStream) -> Result<AstNode> {
     // Measure -> Argument -> Arrow -> Argument -> Semicolon
     let arg_1 = match_argument(tokens)?;
     match_token(tokens, Token::Arrow)?;
@@ -93,90 +115,80 @@ pub fn measure(tokens: &mut Vec<Token>) -> Result<AstNode> {
     Ok(AstNode::Measure(arg_1, arg_2))
 }
 
-pub fn application(tokens: &mut Vec<Token>, id: String) -> Result<AstNode> {
+pub fn application(tokens: &mut TokenStream, id: String) -> Result<AstNode> {
     // id -> argument list -> Semicolon;
     // id -> () -> argument list -> Semicolon;
     // id -> ( Expr list ) ->
-    let params = match match_token_peek(tokens, Token::LParen) {
-        Ok(_) => {
-            tokens.remove(0);
-            match match_token_peek(tokens, Token::RParen) {
-                Ok(_) => {
-                    tokens.remove(0);
-                    vec![]
-                }
-                Err(_) => {
-                    let p = match_mathexpr_list(tokens)?;
-                    match_token(tokens, Token::RParen)?;
-                    p
-                }
-            }
+    let params = if let Some(Token::LParen) = tokens.peek() {
+        tokens.next();
+        if let Some(Token::RParen) = tokens.peek() {
+            tokens.next();
+            vec![]
+        } else {
+            let p = match_mathexpr_list(tokens)?;
+            match_token(tokens, Token::RParen)?;
+            p
         }
-        Err(_) => vec![],
+    } else {
+        vec![]
     };
 
     let list = match_argument_list(tokens)?;
     match_semicolon(tokens)?;
+
     Ok(AstNode::ApplyGate(id, list, params))
 }
 
-pub fn opaque(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn opaque(tokens: &mut TokenStream) -> Result<AstNode> {
     // opaque -> id -> argument list -> Semicolon;
     // opaque -> id -> () -> argument list -> Semicolon;
     // opaque -> id -> ( Expr list ) ->
     let id = match_identifier(tokens)?;
-    let params = match match_token_peek(tokens, Token::LParen) {
-        Ok(_) => {
-            tokens.remove(0);
-            match match_token_peek(tokens, Token::RParen) {
-                Ok(_) => {
-                    tokens.remove(0);
-                    vec![]
-                }
-                Err(_) => {
-                    let p = match_id_list(tokens)?;
-                    match_token(tokens, Token::RParen)?;
-                    p
-                }
-            }
+
+    let params = if let Some(Token::LParen) = tokens.peek() {
+        tokens.next();
+        if let Some(Token::RParen) = tokens.peek() {
+            tokens.next();
+            vec![]
+        } else {
+            let p = match_id_list(tokens)?;
+            match_token(tokens, Token::RParen)?;
+            p
         }
-        Err(_) => vec![],
+    } else {
+        vec![]
     };
 
     let list = match_argument_list(tokens)?;
     match_semicolon(tokens)?;
+
     Ok(AstNode::Opaque(id, list, params))
 }
 
-pub fn gate(tokens: &mut Vec<Token>) -> Result<AstNode> {
+pub fn gate(tokens: &mut TokenStream) -> Result<AstNode> {
     // gate -> id -> argument list -> { -> list of applications -> }
     // gate -> id -> () -> argument list ->{ -> list of applications -> }
     // gate -> id -> ( Expr list ) -> { -> list of applications -> }
     let id = match_identifier(tokens)?;
 
-    let params = match match_token_peek(tokens, Token::LParen) {
-        Ok(_) => {
-            tokens.remove(0);
-            match match_token_peek(tokens, Token::RParen) {
-                Ok(_) => {
-                    tokens.remove(0);
-                    vec![]
-                }
-                Err(_) => {
-                    let p = match_id_list(tokens)?;
-                    match_token(tokens, Token::RParen)?;
-                    p
-                }
-            }
+    let params = if let Some(Token::LParen) = tokens.peek() {
+        tokens.next();
+        if let Some(Token::RParen) = tokens.peek() {
+            tokens.next();
+            vec![]
+        } else {
+            let p = match_id_list(tokens)?;
+            match_token(tokens, Token::RParen)?;
+            p
         }
-        Err(_) => vec![],
+    } else {
+        vec![]
     };
 
     let list = match_id_list(tokens)?;
-
     match_token(tokens, Token::LCParen)?;
 
-    let applications = if tokens[0] != Token::RCParen {
+    let applications = if tokens.peek().ok_or(Error::SourceError)? != &&Token::RCParen {
         match_application_list(tokens)?
     } else {
         vec![]
@@ -190,76 +202,60 @@ pub fn gate(tokens: &mut Vec<Token>) -> Result<AstNode> {
 //////////////////////////////////////////////////////////////////////
 // Terminals
 //////////////////////////////////////////////////////////////////////
-pub fn match_application_list(tokens: &mut Vec<Token>) -> Result<Vec<AstNode>> {
-    let mut args = vec![];
+pub fn match_application_list(tokens: &mut TokenStream) -> Result<Vec<AstNode>> {
     let id = match_identifier(tokens)?;
-
     let head = application(tokens, id)?;
+    let mut args = vec![head];
 
-    args.push(head);
-
-    if let Token::Id(_) = tokens[0] {
-        let tail = match_application_list(tokens)?;
-        for t in tail {
-            args.push(t);
-        }
+    while let &Token::Id(id) = tokens.peek().ok_or(Error::SourceError)? {
+        let tail = application(tokens, id.clone())?;
+        args.push(tail);
     }
+
     Ok(args)
 }
 
-pub fn match_argument_list(tokens: &mut Vec<Token>) -> Result<Vec<Argument>> {
-    let mut args = vec![];
+pub fn match_argument_list(tokens: &mut TokenStream) -> Result<Vec<Argument>> {
     let head = match_argument(tokens)?;
+    let mut args = vec![head];
 
-    args.push(head);
-
-    if match_token_peek(tokens, Token::Comma).is_ok() {
-        tokens.remove(0);
-        let tail = match_argument_list(tokens)?;
-        for t in tail {
-            args.push(t);
-        }
+    while let Some(Token::Comma) = tokens.peek() {
+        tokens.next();
+        let tail = match_argument(tokens)?;
+        args.push(tail);
     }
 
     Ok(args)
 }
 
-pub fn match_mathexpr_list(tokens: &mut Vec<Token>) -> Result<Vec<String>> {
-    let mut args = vec![];
+pub fn match_mathexpr_list(tokens: &mut TokenStream) -> Result<Vec<String>> {
     let head = match_mathexpr(tokens)?;
+    let mut args = vec![head];
 
-    args.push(head);
-
-    if match_token_peek(tokens, Token::Comma).is_ok() {
-        tokens.remove(0);
-        let tail = match_mathexpr_list(tokens)?;
-        for t in tail {
-            args.push(t);
-        }
+    while let Some(Token::Comma) = tokens.peek() {
+        tokens.next();
+        let tail = match_mathexpr(tokens)?;
+        args.push(tail);
     }
 
     Ok(args)
 }
 
-pub fn match_id_list(tokens: &mut Vec<Token>) -> Result<Vec<String>> {
-    let mut args = vec![];
+pub fn match_id_list(tokens: &mut TokenStream) -> Result<Vec<String>> {
     let head = match_identifier(tokens)?;
+    let mut args = vec![head];
 
-    args.push(head);
-
-    if match_token_peek(tokens, Token::Comma).is_ok() {
-        tokens.remove(0);
-        let tail = match_id_list(tokens)?;
-        for t in tail {
-            args.push(t);
-        }
+    while let Some(Token::Comma) = tokens.peek() {
+        tokens.next();
+        let tail = match_identifier(tokens)?;
+        args.push(tail);
     }
 
     Ok(args)
 }
 
-pub fn match_mathexpr(tokens: &mut Vec<Token>) -> Result<String> {
-    if tokens.is_empty() {
+pub fn match_mathexpr(tokens: &mut TokenStream) -> Result<String> {
+    if let None = tokens.peek() {
         return Err(Error::SourceError);
     }
 
@@ -267,8 +263,8 @@ pub fn match_mathexpr(tokens: &mut Vec<Token>) -> Result<String> {
     let mut num_open_paren = 0;
 
     // Parse until we find a comma, semicolon or a non matching paren
-    while !tokens.is_empty() {
-        let string: String = match tokens[0].clone() {
+    while let Some(token) = tokens.peek().cloned() {
+        let string: String = match token.clone() {
             Token::Real(f) => f.to_string(),
             Token::NNInteger(n) => n.to_string(),
             Token::Id(i) => i,
@@ -297,7 +293,7 @@ pub fn match_mathexpr(tokens: &mut Vec<Token>) -> Result<String> {
             _ => return Ok(expr_string),
         };
 
-        tokens.remove(0);
+        tokens.next();
         expr_string.push_str(" ");
         expr_string.push_str(&string);
         expr_string.push_str(" ");
@@ -306,77 +302,65 @@ pub fn match_mathexpr(tokens: &mut Vec<Token>) -> Result<String> {
     Ok(expr_string)
 }
 
-pub fn match_argument(tokens: &mut Vec<Token>) -> Result<Argument> {
+pub fn match_argument(tokens: &mut TokenStream) -> Result<Argument> {
     let id = match_identifier(tokens)?;
 
-    match match_token_peek(tokens, Token::LSParen) {
-        Ok(()) => {
-            tokens.remove(0);
-            let n = match_nninteger(tokens)?;
-            match_token(tokens, Token::RSParen)?;
-            Ok(Argument::Qubit(id, n))
-        }
-        Err(_) => Ok(Argument::Register(id)),
+    if let Some(Token::LSParen) = tokens.peek() {
+        tokens.next();
+        let n = match_nninteger(tokens)?;
+        match_token(tokens, Token::RSParen)?;
+        Ok(Argument::Qubit(id, n))
+    } else {
+        Ok(Argument::Register(id))
     }
 }
 
-pub fn match_real(tokens: &mut Vec<Token>) -> Result<f32> {
-    if tokens.is_empty() {
-        return Err(Error::SourceError);
-    }
-    match tokens.remove(0) {
-        Token::Real(n) => Ok(n),
-        _ => Err(Error::MissingReal),
+pub fn match_real(tokens: &mut TokenStream) -> Result<f32> {
+    match tokens.next() {
+        Some(Token::Real(n)) => Ok(*n),
+        Some(_) => Err(Error::MissingReal),
+        None => Err(Error::SourceError),
     }
 }
 
-pub fn match_nninteger(tokens: &mut Vec<Token>) -> Result<i32> {
-    if tokens.is_empty() {
-        return Err(Error::SourceError);
-    }
-    match tokens.remove(0) {
-        Token::NNInteger(n) => Ok(n),
-        _ => Err(Error::MissingInt),
+pub fn match_nninteger(tokens: &mut TokenStream) -> Result<i32> {
+    match tokens.next() {
+        Some(Token::NNInteger(n)) => Ok(*n),
+        Some(_) => Err(Error::MissingInt),
+        None => Err(Error::SourceError),
     }
 }
 
-pub fn match_identifier(tokens: &mut Vec<Token>) -> Result<String> {
-    if tokens.is_empty() {
+pub fn match_identifier(tokens: &mut TokenStream) -> Result<String> {
+    if let None = tokens.peek() {
         return Err(Error::SourceError);
     }
-    match tokens.remove(0) {
-        Token::Id(s) => Ok(s),
-        _ => Err(Error::MissingIdentifier),
+    match tokens.next() {
+        Some(Token::Id(s)) => Ok(s.clone()),
+        Some(_) => Err(Error::MissingIdentifier),
+        None => Err(Error::SourceError),
     }
 }
 
-pub fn match_token(tokens: &mut Vec<Token>, token: Token) -> Result<()> {
-    if tokens.is_empty() {
-        return Err(Error::SourceError);
+pub fn match_token(tokens: &mut TokenStream, eq_token: Token) -> Result<()> {
+    match tokens.next() {
+        Some(token) if &eq_token == token => Ok(()),
+        _ => Err(Error::SourceError),
     }
-    if tokens.remove(0) != token {
-        return Err(Error::SourceError);
-    }
-    Ok(())
 }
 
-pub fn match_token_peek(tokens: &mut Vec<Token>, token: Token) -> Result<()> {
-    if tokens.is_empty() {
-        return Err(Error::SourceError);
+#[allow(dead_code)]
+pub fn match_token_peek(tokens: &mut TokenStream, eq_token: Token) -> Result<()> {
+    match tokens.peek().copied() {
+        Some(token) if &eq_token == token => Ok(()),
+        _ => Err(Error::SourceError),
     }
-    if tokens[0] != token {
-        return Err(Error::SourceError);
-    }
-    Ok(())
 }
 
-pub fn match_semicolon(tokens: &mut Vec<Token>) -> Result<()> {
-    if tokens.is_empty() {
-        return Err(Error::SourceError);
+pub fn match_semicolon(tokens: &mut TokenStream) -> Result<()> {
+    match tokens.next() {
+        Some(&Token::Semicolon) => Ok(()),
+        Some(_) => Err(Error::MissingSemicolon),
+        _ => Err(Error::SourceError),
     }
-
-    if tokens.remove(0) != Token::Semicolon {
-        return Err(Error::MissingSemicolon);
-    }
-    Ok(())
 }


### PR DESCRIPTION
Rewrite code with peekable iterator. Use safe notation ```tokens.peek()``` and ```tokens.next()``` instead of ```tokens[0]``` and ```tokens.remove(0)```. Such refactoring also allow to use immutable ref for parse function.